### PR TITLE
Fixed the auth middleware without breaking previous code!

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,25 +1,25 @@
 var jwt = require("jsonwebtoken");
+var User = require('../models/user')
 
+module.exports = async(req, res, next) => {
+  try {
 
-module.exports = (req, res, next) => {
-    try {
+    // console.log('authorization: ', req.cookies);
+    const token = req.cookies.authorization;
+    // console.log(token);
+    jwt.verify(token, process.env.JWT_SECRET, async(err, user) => {
+      if (err)
+        console.log(err);
+      else {
+        req.user = user;
+        req.dbUser = await User.findById(user.userId)
+      }
+      // console.log(req.user);
+      next();
+    });
 
-        // console.log('authorization: ', req.cookies);
-        const token = req.cookies.authorization;
-        // console.log(token);
-        jwt.verify(token, process.env.JWT_SECRET,(err,user)=>{
-            if(err)
-                console.log(err);
-            else
-                req.user = user;
-            
-            // console.log(req.user);
-            next();
-        });
-        
-    } catch (error) {
-        // res.status(401).json({ message: "Authentication failed!" });
-        res.redirect("/login");
-    }
+  } catch (error) {
+    // res.status(401).json({ message: "Authentication failed!" });
+    res.redirect("/login");
+  }
 };
-


### PR DESCRIPTION
The auth middleware now adds a ```req.dbUser``` and stores the user from the database here. ```req.user``` was used to store the jwt payload which was not correct but modifying that will result in breaking previous code as routes may have been made around this bug.